### PR TITLE
Reuse available functions

### DIFF
--- a/src/api/rest.tsx
+++ b/src/api/rest.tsx
@@ -98,10 +98,6 @@ export const getBusinessServices = (
   return APIClient.get(`${BUSINESS_SERVICES}?${query.join("&")}`, { headers });
 };
 
-export const getAllBusinessServices = (): AxiosPromise<BusinessServicePage> => {
-  return APIClient.get(`${BUSINESS_SERVICES}?size=1000&sort=name`, { headers });
-};
-
 export const deleteBusinessService = (id: number | string): AxiosPromise => {
   return APIClient.delete(`${BUSINESS_SERVICES}/${id}`);
 };
@@ -184,12 +180,6 @@ export const getStakeholders = (
   return APIClient.get(`${STAKEHOLDERS}?${query.join("&")}`, { headers });
 };
 
-export const getAllStakeholders = (): AxiosPromise<StakeholderPage> => {
-  return APIClient.get(`${STAKEHOLDERS}?size=1000&sort=displayName`, {
-    headers,
-  });
-};
-
 export const deleteStakeholder = (id: number): AxiosPromise => {
   return APIClient.delete(`${STAKEHOLDERS}/${id}`);
 };
@@ -256,12 +246,6 @@ export const getStakeholderGroups = (
   return APIClient.get(`${STAKEHOLDER_GROUPS}?${query.join("&")}`, { headers });
 };
 
-export const getAllStakeholderGroups = (): AxiosPromise<StakeholderGroupPage> => {
-  return APIClient.get(`${STAKEHOLDER_GROUPS}?size=1000&sort=name`, {
-    headers,
-  });
-};
-
 export const deleteStakeholderGroup = (id: number): AxiosPromise => {
   return APIClient.delete(`${STAKEHOLDER_GROUPS}/${id}`);
 };
@@ -280,8 +264,40 @@ export const updateStakeholderGroup = (
 
 // Job functions
 
-export const getAllJobFunctions = (): AxiosPromise<JobFunctionPage> => {
-  return APIClient.get(`${JOB_FUNCTIONS}?size=1000&sort=role`, { headers });
+export enum JobFunctionSortBy {
+  ROLE,
+}
+export interface JobFunctionSortByQuery {
+  field: JobFunctionSortBy;
+  direction?: Direction;
+}
+
+export const getJobFunctions = (
+  filters: {},
+  pagination: PageQuery,
+  sortBy?: JobFunctionSortByQuery
+): AxiosPromise<JobFunctionPage> => {
+  let sortByQuery: string | undefined = undefined;
+  if (sortBy) {
+    let field;
+    switch (sortBy.field) {
+      case JobFunctionSortBy.ROLE:
+        field = "role";
+        break;
+      default:
+        throw new Error("Could not define SortBy field name");
+    }
+    sortByQuery = `${sortBy.direction === "desc" ? "-" : ""}${field}`;
+  }
+
+  const params = {
+    page: pagination.page - 1,
+    size: pagination.perPage,
+    sort: sortByQuery,
+  };
+
+  const query: string[] = buildQuery(params);
+  return APIClient.get(`${JOB_FUNCTIONS}?${query.join("&")}`, { headers });
 };
 
 // App inventory

--- a/src/shared/hooks/useFetchBusinessServices/useFetchBusinessServices.test.tsx
+++ b/src/shared/hooks/useFetchBusinessServices/useFetchBusinessServices.test.tsx
@@ -2,11 +2,7 @@ import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { renderHook, act } from "@testing-library/react-hooks";
 import { useFetchBusinessServices } from "./useFetchBusinessServices";
-import {
-  BusinessService,
-  BusinessServicePage,
-  PageRepresentation,
-} from "api/models";
+import { BusinessServicePage } from "api/models";
 import { BUSINESS_SERVICES } from "api/rest";
 
 describe("useFetchBusinessServices", () => {
@@ -96,7 +92,7 @@ describe("useFetchBusinessServices", () => {
     };
 
     new MockAdapter(axios)
-      .onGet(`${BUSINESS_SERVICES}?size=1000&sort=name`)
+      .onGet(`${BUSINESS_SERVICES}?page=0&size=1000&sort=name`)
       .reply(200, data);
 
     // Use hook

--- a/src/shared/hooks/useFetchBusinessServices/useFetchBusinessServices.ts
+++ b/src/shared/hooks/useFetchBusinessServices/useFetchBusinessServices.ts
@@ -4,8 +4,8 @@ import { ActionType, createAsyncAction, getType } from "typesafe-actions";
 
 import {
   getBusinessServices,
-  getAllBusinessServices,
   BusinessServiceSortByQuery,
+  BusinessServiceSortBy,
 } from "api/rest";
 import { PageRepresentation, BusinessService, PageQuery } from "api/models";
 
@@ -125,7 +125,11 @@ export const useFetchBusinessServices = (
   const fetchAllBusinessServices = useCallback(() => {
     dispatch(fetchRequest());
 
-    getAllBusinessServices()
+    getBusinessServices(
+      {},
+      { page: 1, perPage: 1000 },
+      { field: BusinessServiceSortBy.NAME }
+    )
       .then(({ data }) => {
         const list = data._embedded["business-service"];
         const total = data.total_count;

--- a/src/shared/hooks/useFetchJobFunctions/useFetchJobFunctions.test.tsx
+++ b/src/shared/hooks/useFetchJobFunctions/useFetchJobFunctions.test.tsx
@@ -16,7 +16,7 @@ describe("useFetchJobFunctions", () => {
     };
 
     new MockAdapter(axios)
-      .onGet(`${JOB_FUNCTIONS}?size=1000&sort=role`)
+      .onGet(`${JOB_FUNCTIONS}?page=0&size=1000&sort=role`)
       .reply(200, data);
 
     // Use hook

--- a/src/shared/hooks/useFetchJobFunctions/useFetchJobFunctions.ts
+++ b/src/shared/hooks/useFetchJobFunctions/useFetchJobFunctions.ts
@@ -2,7 +2,7 @@ import { useCallback, useReducer } from "react";
 import { AxiosError } from "axios";
 import { ActionType, createAsyncAction, getType } from "typesafe-actions";
 
-import { getAllJobFunctions } from "api/rest";
+import { getJobFunctions, JobFunctionSortBy } from "api/rest";
 import { PageRepresentation, JobFunction } from "api/models";
 
 export const {
@@ -83,7 +83,11 @@ export const useFetchJobFunctions = (
   const fetchAllJobFunctions = useCallback(() => {
     dispatch(fetchRequest());
 
-    getAllJobFunctions()
+    getJobFunctions(
+      {},
+      { page: 1, perPage: 1000 },
+      { field: JobFunctionSortBy.ROLE }
+    )
       .then(({ data }) => {
         const list = data._embedded["job-function"];
         const total = data.total_count;

--- a/src/shared/hooks/useFetchStakeholderGroups/useFetchStakeholderGroups.test.tsx
+++ b/src/shared/hooks/useFetchStakeholderGroups/useFetchStakeholderGroups.test.tsx
@@ -90,7 +90,7 @@ describe("useFetchStakeholderGroups", () => {
     };
 
     new MockAdapter(axios)
-      .onGet(`${STAKEHOLDER_GROUPS}?size=1000&sort=name`)
+      .onGet(`${STAKEHOLDER_GROUPS}?page=0&size=1000&sort=name`)
       .reply(200, data);
 
     // Use hook

--- a/src/shared/hooks/useFetchStakeholderGroups/useFetchStakeholderGroups.ts
+++ b/src/shared/hooks/useFetchStakeholderGroups/useFetchStakeholderGroups.ts
@@ -4,7 +4,7 @@ import { ActionType, createAsyncAction, getType } from "typesafe-actions";
 
 import {
   getStakeholderGroups,
-  getAllStakeholderGroups,
+  StakeholderGroupSortBy,
   StakeholderGroupSortByQuery,
 } from "api/rest";
 import { PageRepresentation, StakeholderGroup, PageQuery } from "api/models";
@@ -129,7 +129,11 @@ export const useFetchStakeholderGroups = (
   const fetchAllStakeholderGroups = useCallback(() => {
     dispatch(fetchRequest());
 
-    getAllStakeholderGroups()
+    getStakeholderGroups(
+      {},
+      { page: 1, perPage: 1000 },
+      { field: StakeholderGroupSortBy.NAME }
+    )
       .then(({ data }) => {
         const list = data._embedded["stakeholder-group"];
         const total = data.total_count;

--- a/src/shared/hooks/useFetchStakeholders/useFetchStakeholders.test.tsx
+++ b/src/shared/hooks/useFetchStakeholders/useFetchStakeholders.test.tsx
@@ -90,7 +90,7 @@ describe("useFetchStakeholders", () => {
     };
 
     new MockAdapter(axios)
-      .onGet(`${STAKEHOLDERS}?size=1000&sort=displayName`)
+      .onGet(`${STAKEHOLDERS}?page=0&size=1000&sort=displayName`)
       .reply(200, data);
 
     // Use hook

--- a/src/shared/hooks/useFetchStakeholders/useFetchStakeholders.ts
+++ b/src/shared/hooks/useFetchStakeholders/useFetchStakeholders.ts
@@ -4,7 +4,7 @@ import { ActionType, createAsyncAction, getType } from "typesafe-actions";
 
 import {
   getStakeholders,
-  getAllStakeholders,
+  StakeholderSortBy,
   StakeholderSortByQuery,
 } from "api/rest";
 import { PageRepresentation, Stakeholder, PageQuery } from "api/models";
@@ -131,7 +131,11 @@ export const useFetchStakeholders = (
   const fetchAllStakeholders = useCallback(() => {
     dispatch(fetchRequest());
 
-    getAllStakeholders()
+    getStakeholders(
+      {},
+      { page: 1, perPage: 1000 },
+      { field: StakeholderSortBy.DISPLAY_NAME }
+    )
       .then(({ data }) => {
         const list = data._embedded.stakeholder;
         const total = data.total_count;


### PR DESCRIPTION
I think this is a good opportunity to refactoring and enhance the current `rest.tsx` file.

- I'm removing all functions "FetchAll" from `rest.tsx` and move their code to the already existing Hooks. The reason is that the `FechAll` functions are using exactly the same logic as the other functions e.g. 

This block of code: 
```
export const getAllBusinessServices = (): AxiosPromise<BusinessServicePage> => {
  return APIClient.get(`${BUSINESS_SERVICES}?size=1000&sort=name`, { headers });
};
```

Can be 100% replaced reusing:
```
export const getBusinessServices = (
  filters: {
    name?: string[];
    description?: string[];
    owner?: string[];
  },
  pagination: PageQuery,
  sortBy?: BusinessServiceSortByQuery
)
```

This way we reuse code; we also avoid using plain text in the QueryParameters e.g. `?size=1000&sort=name`.