### PR TITLE
Use NodeJS 12 and  not the default NodeJS version (16.x)

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -92,6 +92,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
       - name: Keycloak Admin CLI
         uses: carlosthe19916/keycloak-action@0.4
         with:


### PR DESCRIPTION
The default NodeJS version used in `ubuntu-latest` has changed from NodeJS 12.x to 16.x so we need to set the version explicitly